### PR TITLE
Binary mode: element-wise array serialisation (for CAN)

### DIFF
--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1747,12 +1747,12 @@ typedef int (*thingset_iterate_subsets_callback_t)(struct thingset_data_object *
  * Iterate over all objects of given subset(s), invoking the supplied callback for each object.
  * If elementwise_array_updates is set to true on the ThingSet context, the callback will be
  * invoked for each element of any arrays.
- * 
+ *
  * @param ts Pointer to ThingSet context.
  * @param subsets Flags to select which subset(s) of data items should be iterated over
  * @param callback The callback to be invoked for each object and, optionally, array element.
  * @param callback_context Pointer to data to be passed to the callback.
- * 
+ *
  * @return 0 on success; a negative ThingSet response code in case of error.
  */
 int thingset_for_object_in_subsets(struct thingset_context *ts, uint16_t subset, thingset_iterate_subsets_callback_t callback, void *callback_context);

--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1396,7 +1396,7 @@ union thingset_data_pointer {
     uint32_t subset;                  /**< Subset flag(s) */
     void (*void_fn)();                /**< Pointer to function with void return value */
     int32_t (*i32_fn)();              /**< Pointer to function with int32_t return value */
-    /**< Pointer to thingset_array_element struct */
+    /** Pointer to thingset_array_element struct */
     struct thingset_array_element *array_element;
     /** Pointer to group callback function */
     thingset_group_callback_t group_callback;
@@ -1445,8 +1445,8 @@ struct thingset_array
  */
 struct thingset_array_element
 {
-    struct thingset_array *array;
-    uint16_t index;
+    struct thingset_array *array; /**< Pointer to array */
+    uint16_t index;               /**< Index of element in array */
 };
 
 /**
@@ -1580,12 +1580,6 @@ struct thingset_context
     const uint8_t *msg_payload;
 
     /**
-     * Payload may contain an update for a single element in an array,
-     * so any two-element arrays should be interpreted as such.
-     */
-    bool elementwise_array_updates;
-
-    /**
      * Pointer to the response buffer (provided by process function)
      */
     uint8_t *rsp;
@@ -1638,6 +1632,12 @@ struct thingset_context
      * Stores current authentication status (authentication as "normal" user as default)
      */
     uint8_t auth_flags;
+
+    /**
+     * Payload may contain an update for a single element in an array,
+     * so any two-element arrays should be interpreted as such.
+     */
+    bool elementwise_array_updates;
 
     /**
      * Stores current authentication status (authentication as "normal" user as default)

--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1738,6 +1738,26 @@ int thingset_export_item(struct thingset_context *ts, uint8_t *buf, size_t buf_s
                          const struct thingset_data_object *obj, enum thingset_data_format format);
 
 /**
+ * Function to be called for each data object in a given subset. Returns 0 or
+ * a negative ThingSet response code in case of error.
+ */
+typedef int (*thingset_iterate_subsets_callback_t)(struct thingset_data_object *obj, void *callback_context);
+
+/**
+ * Iterate over all objects of given subset(s), invoking the supplied callback for each object.
+ * If elementwise_array_updates is set to true on the ThingSet context, the callback will be
+ * invoked for each element of any arrays.
+ * 
+ * @param ts Pointer to ThingSet context.
+ * @param subsets Flags to select which subset(s) of data items should be iterated over
+ * @param callback The callback to be invoked for each object and, optionally, array element.
+ * @param callback_context Pointer to data to be passed to the callback.
+ * 
+ * @return 0 on success; a negative ThingSet response code in case of error.
+ */
+int thingset_for_object_in_subsets(struct thingset_context *ts, uint16_t subset, thingset_iterate_subsets_callback_t callback, void *callback_context);
+
+/**
  * Iterate over all objects of given subset(s).
  *
  * @param ts Pointer to ThingSet context.

--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1578,7 +1578,7 @@ struct thingset_context
      * Pointer to the start of the payload in the message buffer
      */
     const uint8_t *msg_payload;
-    
+
     /**
      * Payload may contain an update for a single element in an array,
      * so any two-element arrays should be interpreted as such.

--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1358,6 +1358,8 @@ enum thingset_type
     THINGSET_TYPE_SUBSET,  /**< Subset of data items */
     THINGSET_TYPE_FN_VOID, /**< Function with void return value */
     THINGSET_TYPE_FN_I32,  /**< Function with int32_t return value */
+    /**< Element of an array (used when transmitting over classical CAN) */
+    THINGSET_TYPE_ARRAY_ELEMENT,
 };
 
 /**
@@ -1394,6 +1396,8 @@ union thingset_data_pointer {
     uint32_t subset;                  /**< Subset flag(s) */
     void (*void_fn)();                /**< Pointer to function with void return value */
     int32_t (*i32_fn)();              /**< Pointer to function with int32_t return value */
+    /**< Pointer to thingset_array_element struct */
+    struct thingset_array_element *array_element;
     /** Pointer to group callback function */
     thingset_group_callback_t group_callback;
 };
@@ -1434,6 +1438,15 @@ struct thingset_array
     const int16_t decimals;                /**< See detail in struct thingset_data_object */
     const uint16_t max_elements;           /**< Maximum number of elements in the array */
     uint16_t num_elements;                 /**< Actual number of elements in the array */
+};
+
+/**
+ * Data structure used to specify an element in an array
+ */
+struct thingset_array_element
+{
+    struct thingset_array *array;
+    uint16_t index;
 };
 
 /**
@@ -1565,6 +1578,12 @@ struct thingset_context
      * Pointer to the start of the payload in the message buffer
      */
     const uint8_t *msg_payload;
+    
+    /**
+     * Payload may contain an update for a single element in an array,
+     * so any two-element arrays should be interpreted as such.
+     */
+    bool elementwise_array_updates;
 
     /**
      * Pointer to the response buffer (provided by process function)

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -201,14 +201,14 @@ static int bin_serialize_value(struct thingset_context *ts,
         success = success && zcbor_list_end_encode(ts->encoder, array->num_elements);
     }
     else if (object->type == THINGSET_TYPE_ARRAY_ELEMENT) {
-        /* should only end up here when serialising reports for transmission over CAN 
+        /* should only end up here when serialising reports for transmission over CAN
          * Two element list containing:
            - index position in source array
            - element value
          */
 
         struct thingset_array_element *element = object->data.array_element;
-        
+
         size_t type_size = thingset_type_size(element->array->element_type);
         union thingset_data_pointer data = { .u8 = element->array->elements.u8 + element->index * type_size };
         success = zcbor_list_start_encode(ts->encoder, 2);
@@ -576,7 +576,7 @@ static int bin_deserialize_value(struct thingset_context *ts,
     if (err == -THINGSET_ERR_UNSUPPORTED_FORMAT && object->type == THINGSET_TYPE_ARRAY) {
         struct thingset_array *array = object->data.array;
         bool success;
-        
+
         success = zcbor_list_start_decode(ts->decoder);
         if (!success) {
             return -THINGSET_ERR_UNSUPPORTED_FORMAT;
@@ -586,7 +586,7 @@ static int bin_deserialize_value(struct thingset_context *ts,
         int index = 0;
         if (ts->decoder->elem_count == 2 && ts->elementwise_array_updates) {
             /* update of one element in a larger array */
-            
+
             /* index of updated element */
             success = success & zcbor_uint32_decode(ts->decoder, &index);
             if (index >= object->data.array->num_elements) {

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -200,6 +200,26 @@ static int bin_serialize_value(struct thingset_context *ts,
 
         success = success && zcbor_list_end_encode(ts->encoder, array->num_elements);
     }
+    else if (object->type == THINGSET_TYPE_ARRAY_ELEMENT) {
+        /* should only end up here when serialising reports for transmission over CAN 
+         * Two element list containing:
+           - index position in source array
+           - element value
+         */
+
+        struct thingset_array_element *element = object->data.array_element;
+        
+        size_t type_size = thingset_type_size(element->array->element_type);
+        union thingset_data_pointer data = { .u8 = element->array->elements.u8 + element->index * type_size };
+        success = zcbor_list_start_encode(ts->encoder, 2);
+        success = success && zcbor_uint32_put(ts->encoder, element->index);
+        err =
+            bin_serialize_simple_value(ts->encoder, data, element->array->element_type, element->array->decimals);
+        if (err != 0) {
+            return err;
+        }
+        success = success && zcbor_list_end_encode(ts->encoder, 2);
+    }
     else {
         return -THINGSET_ERR_UNSUPPORTED_FORMAT;
     }
@@ -556,7 +576,7 @@ static int bin_deserialize_value(struct thingset_context *ts,
     if (err == -THINGSET_ERR_UNSUPPORTED_FORMAT && object->type == THINGSET_TYPE_ARRAY) {
         struct thingset_array *array = object->data.array;
         bool success;
-
+        
         success = zcbor_list_start_decode(ts->decoder);
         if (!success) {
             return -THINGSET_ERR_UNSUPPORTED_FORMAT;
@@ -564,23 +584,39 @@ static int bin_deserialize_value(struct thingset_context *ts,
 
         size_t type_size = thingset_type_size(array->element_type);
         int index = 0;
-        do {
-            /* using uint8_t pointer for byte-wise pointer arithmetics */
+        if (ts->decoder->elem_count == 2 && ts->elementwise_array_updates) {
+            /* update of one element in a larger array */
+            
+            /* index of updated element */
+            success = success & zcbor_uint32_decode(ts->decoder, &index);
+            if (index >= object->data.array->num_elements) {
+                return -THINGSET_ERR_UNSUPPORTED_FORMAT;
+            }
             union thingset_data_pointer data = { .u8 = array->elements.u8 + index * type_size };
-
             err = bin_deserialize_simple_value(ts, data, array->element_type, array->decimals,
                                                check_only);
             if (err != 0) {
-                break;
+                return -THINGSET_ERR_UNSUPPORTED_FORMAT;
             }
-            index++;
-        } while (index < array->num_elements);
+        } else {
+            do {
+                /* using uint8_t pointer for byte-wise pointer arithmetics */
+                union thingset_data_pointer data = { .u8 = array->elements.u8 + index * type_size };
 
-        if (!check_only) {
-            array->num_elements = index;
+                err = bin_deserialize_simple_value(ts, data, array->element_type, array->decimals,
+                                                   check_only);
+                if (err != 0) {
+                    break;
+                }
+                index++;
+            } while (index < array->num_elements);
+
+            if (!check_only) {
+                array->num_elements = index;
+            }
         }
+        success = success && zcbor_list_end_decode(ts->decoder);
 
-        success = zcbor_list_end_decode(ts->decoder);
         if (success) {
             err = 0;
         }

--- a/tests/common/data.c
+++ b/tests/common/data.c
@@ -69,6 +69,9 @@ static THINGSET_DEFINE_INT64_ARRAY(i64_arr_item, i64_arr, 3);
 float f32_arr[100] = { -1.1, -2.2, -3.3 };
 static THINGSET_DEFINE_FLOAT_ARRAY(f32_arr_item, 1, f32_arr, 3);
 
+float f32_live_arr[100] = { -1.1, -2.2, -3.3 };
+static THINGSET_DEFINE_FLOAT_ARRAY(f32_live_arr_item, 1, f32_live_arr, 3);
+
 #if CONFIG_THINGSET_DECFRAC_TYPE_SUPPORT
 int32_t decfrac_arr[100] = { -32 };
 static THINGSET_DEFINE_DECFRAC_ARRAY(decfrac_arr_item, 2, decfrac_arr, 1);
@@ -236,6 +239,7 @@ THINGSET_ADD_ITEM_ARRAY(0x300, 0x30A, "wF32", &f32_arr_item, THINGSET_ANY_RW, 0)
 #if CONFIG_THINGSET_DECFRAC_TYPE_SUPPORT
 THINGSET_ADD_ITEM_ARRAY(0x300, 0x30B, "wDecFrac", &decfrac_arr_item, THINGSET_ANY_RW, 0);
 #endif
+THINGSET_ADD_ITEM_ARRAY(0x300, 0x30C, "wF32Live", &f32_live_arr_item, THINGSET_ANY_RW, SUBSET_ELEM_ARRAY_LIVE);
 
 /* Exec */
 THINGSET_ADD_GROUP(THINGSET_ID_ROOT, 0x400, "Exec", THINGSET_NO_CALLBACK);
@@ -346,6 +350,7 @@ struct thingset_data_object data_objects[] = {
 #if CONFIG_THINGSET_DECFRAC_TYPE_SUPPORT
     THINGSET_ITEM_ARRAY(0x300, 0x30B, "wDecFrac", &decfrac_arr_item, THINGSET_ANY_RW, 0),
 #endif
+    THINGSET_ITEM_ARRAY(0x300, 0x30C, "wF32Live", &f32_live_arr_item, THINGSET_ANY_RW, SUBSET_ELEM_ARRAY_LIVE),
 
     /* Exec */
     THINGSET_GROUP(THINGSET_ID_ROOT, 0x400, "Exec", THINGSET_NO_CALLBACK),

--- a/tests/common/data.h
+++ b/tests/common/data.h
@@ -9,6 +9,7 @@
 
 #define SUBSET_LIVE (1U << 0)
 #define SUBSET_NVM  (2U << 0)
+#define SUBSET_ELEM_ARRAY_LIVE (4U << 0) /* separate group for element array tests */
 
 extern uint32_t timestamp;
 

--- a/tests/protocol/src/elemental_array_reports.c
+++ b/tests/protocol/src/elemental_array_reports.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) The ThingSet Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include <thingset.h>
+
+#include "../../src/thingset_internal.h"
+
+#include "test_utils.h"
+#include "data.h"
+
+static struct thingset_context ts;
+
+struct object_callback_data {
+    char **expected_hex;
+    int *expected_size;
+    int num_messages;
+    int expected_num_messages;
+};
+
+static int object_callback(struct thingset_data_object *obj, void *callback_context)
+{
+    if (obj->type == THINGSET_TYPE_ARRAY_ELEMENT) {
+        uint8_t buffer[THINGSET_TEST_BUF_SIZE];
+        struct object_callback_data *data = (struct object_callback_data *)callback_context;
+        int data_len = thingset_export_item(&ts, buffer, THINGSET_TEST_BUF_SIZE, obj, THINGSET_BIN_VALUES_ONLY);
+        zassert_false(data_len < 0);
+        zassert_true(data_len < 8);
+        char *expected_hex = data->expected_hex[data->num_messages];
+        uint8_t expected[THINGSET_TEST_BUF_SIZE];
+        int exp_len = data->expected_size[data->num_messages];
+        hex2bin_spaced(expected_hex, expected, exp_len);
+        zassert_equal(exp_len, data_len);
+        zassert_mem_equal(expected, buffer, exp_len);
+        data->num_messages++;
+    }
+    return 0;
+}
+
+ZTEST(thingset_elemental_array_reports, test_serialize_float_array)
+{
+    char* expected_hex[3];
+    expected_hex[0] = "82 00 FA BF 8C CC CD"; /* -1.1 */
+    expected_hex[1] = "82 01 FA C0 0C CC CD"; /* -2.2 */
+    expected_hex[2] = "82 02 FA C0 53 33 33"; /* -3.3 */
+
+    int expected_sizes[] = { 7, 7, 7 };
+    struct object_callback_data data = {
+        .expected_hex = expected_hex,
+        .expected_size = expected_sizes,
+        .expected_num_messages = 3,
+    };
+    ts.elementwise_array_updates = true;
+    int ret = thingset_for_object_in_subsets(&ts, SUBSET_ELEM_ARRAY_LIVE, object_callback, &data);
+    ts.elementwise_array_updates = false;
+    zassert_false(ret < 0);
+    zassert_equal(3, data.num_messages, "Expected %d; was %d", 3, data.num_messages);
+}
+
+static void *thingset_setup(void)
+{
+    thingset_init_global(&ts);
+
+    return NULL;
+}
+
+ZTEST_SUITE(thingset_elemental_array_reports, NULL, thingset_setup, NULL, NULL, NULL);


### PR DESCRIPTION
Support serialising arrays element-by-element so they can fit in a single classical CAN message