### PR TITLE
Binary mode: Fix serialize_finish function

### DIFF
--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -262,7 +262,7 @@ static int bin_serialize_list_end(struct thingset_context *ts)
 static void bin_serialize_finish(struct thingset_context *ts)
 {
     ts->rsp_pos = ts->encoder->payload - ts->rsp;
-    if (ts->rsp_pos == 2) {
+    if (ts->rsp_pos == 2 && ts->rsp[1] == 0xF6) {
         /* message with empty payload */
         ts->rsp[ts->rsp_pos++] = 0xF6;
     }

--- a/tests/protocol/src/bin.c
+++ b/tests/protocol/src/bin.c
@@ -688,6 +688,27 @@ ZTEST(thingset_bin, test_export_subset_ids)
     THINGSET_ASSERT_EXPORT_HEX_IDS(SUBSET_LIVE, rsp_exp_hex, 21);
 }
 
+ZTEST(thingset_bin, test_export_item)
+{
+    struct thingset_endpoint endpoint;
+    uint8_t buf_act[10];
+    uint8_t buf_exp[10];
+    int ret;
+
+    /*
+     * This value caused issues with previous implementations because it is serialized to 2 bytes
+     * and serialize_finish erroneously added 0xF6.
+     */
+    ret = thingset_endpoint_by_path(&ts, &endpoint, "Types/wU32", strlen("Types/wU32"));
+    zassert_equal(ret, 0);
+
+    ret = thingset_export_item(&ts, buf_act, sizeof(buf_act), endpoint.object,
+                               THINGSET_BIN_VALUES_ONLY);
+    zassert_equal(ret, 2);
+    hex2bin_spaced("18 20", buf_exp, sizeof(buf_exp));
+    zassert_mem_equal(buf_exp, buf_act, 2);
+}
+
 ZTEST(thingset_bin, test_iterate_subsets)
 {
     struct thingset_data_object *obj = NULL;


### PR DESCRIPTION
The function only used the length of the payload to guess if an empty response was created. An additional check of the value of the second byte is required to make sure this is really an empty response.

A new unit test for this edge case was added.