### PR TITLE
Text mode: Add deserialization of arrays

### DIFF
--- a/tests/protocol/src/txt.c
+++ b/tests/protocol/src/txt.c
@@ -330,6 +330,32 @@ ZTEST(thingset_txt, test_update_unknown_object)
     THINGSET_ASSERT_REQUEST_TXT("=Types {\"wI3\" : 52}", ":A4");
 }
 
+ZTEST(thingset_txt, test_update_int32_array)
+{
+    THINGSET_ASSERT_REQUEST_TXT("=Arrays {\"wI32\":[1,2,3]}", ":84");
+
+    zassert_equal(i32_arr[0], 1);
+    zassert_equal(i32_arr[1], 2);
+    zassert_equal(i32_arr[2], 3);
+
+    i32_arr[0] = -1;
+    i32_arr[1] = -2;
+    i32_arr[2] = -3;
+}
+
+ZTEST(thingset_txt, test_update_float_array)
+{
+    THINGSET_ASSERT_REQUEST_TXT("=Arrays {\"wF32\":[1.1,2.2,3.3]}", ":84");
+
+    zassert_equal(f32_arr[0], (float)1.1);
+    zassert_equal(f32_arr[1], (float)2.2);
+    zassert_equal(f32_arr[2], (float)3.3);
+
+    f32_arr[0] = -1.1;
+    f32_arr[1] = -2.2;
+    f32_arr[2] = -3.3;
+}
+
 ZTEST(thingset_txt, test_group_callback)
 {
     group_callback_pre_read_count = 0;


### PR DESCRIPTION
The deserialization of arrays was only supported for binary mode and still missing in text mode. This PR adds this feature.

PR ready for review for anyone interested. I will merge it in a couple of days if no complaints are raised.