### PR TITLE
Binary mode: Add support for getting records using IDs + index

### DIFF
--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1516,7 +1516,7 @@ struct thingset_endpoint
     /** Pointer to the data object in memory (must never be NULL) */
     struct thingset_data_object *object;
     /** Index number or THINGSET_ENDPOINT_INDEX_NONE or THINGSET_ENDPOINT_INDEX_NEW */
-    int index;
+    int32_t index;
     /** Use names or IDs (relevant for binary mode) */
     bool use_ids;
 };

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -325,6 +325,19 @@ static int bin_parse_endpoint(struct thingset_context *ts)
     else if (zcbor_uint32_decode(ts->decoder, &id) == true && id <= UINT16_MAX) {
         err = thingset_endpoint_by_id(ts, &ts->endpoint, id);
     }
+    else if (zcbor_list_start_decode(ts->decoder) == true) {
+        if (zcbor_uint32_decode(ts->decoder, &id) == true && id <= UINT16_MAX) {
+            err = thingset_endpoint_by_id(ts, &ts->endpoint, id);
+            if (err == 0) {
+                if (!zcbor_int32_decode(ts->decoder, &ts->endpoint.index) ||
+                    ts->endpoint.index < 0 || !zcbor_list_end_decode(ts->decoder))
+                {
+                    err = -THINGSET_ERR_BAD_REQUEST;
+                }
+                /* else: ID and index found, return 0 */
+            }
+        }
+    }
 
     if (err != 0) {
         ts->api->serialize_response(ts, -err, "Invalid endpoint");

--- a/tests/protocol/src/bin.c
+++ b/tests/protocol/src/bin.c
@@ -155,15 +155,11 @@ ZTEST(thingset_bin, test_get_num_records_name)
     THINGSET_ASSERT_REQUEST_HEX(req_hex, rsp_exp_hex);
 }
 
-#if 0
-/*
- * For some reason below test fails because rsp_exp_hex is larger than 255 characters.
- */
 ZTEST(thingset_bin, test_get_record_names)
 {
     const char req_hex[] = "01 69 5265636F7264732F31"; /* Records/1 */
     const char rsp_exp_hex[] =
-        "85 AD "
+        "85 F6 AE "
         "63 74 5f 73 02 "                               /* "t_s":2, */
         "65 77 42 6f 6f 6c f5 "                         /* "wBool":true, */
         "63 77 55 38 08 63 77 49 38 27 "                /* "wU8":8,"wI8":-8, */
@@ -172,13 +168,12 @@ ZTEST(thingset_bin, test_get_record_names)
         "64 77 55 36 34 18 40 64 77 49 36 34 38 3f "    /* "wU64":64,"wI64":-64, */
         "64 77 46 33 32 fa c0 4c cc cd "                /* "wF32":-3.2 */
         "68 77 44 65 63 46 72 61 63 c4 82 21 38 1f "    /* "wDecFrac": 4([-2, -32])*/
-        "67 77 53 74 72 69 6e 67 66 73 74 72 69 6e 67"; /* "wString":"string" */
-
-    printf("strlen(rsp_exp_hex): %d\n", strlen(rsp_exp_hex));
+        "67 77 53 74 72 69 6e 67 66 73 74 72 69 6e 67 " /* "wString":"string" */
+        "69 77 46 33 32 41 72 72 61 79 "                /* "wF32Array": */
+        "83 fa 3f 9d 70 a4 fa 40 91 eb 85 fa 40 fc 7a e1"; /* [1.23, 4.56, 7.89] */
 
     THINGSET_ASSERT_REQUEST_HEX(req_hex, rsp_exp_hex);
 }
-#endif
 
 ZTEST(thingset_bin, test_fetch_root_ids)
 {

--- a/tests/protocol/src/bin.c
+++ b/tests/protocol/src/bin.c
@@ -155,6 +155,26 @@ ZTEST(thingset_bin, test_get_num_records_name)
     THINGSET_ASSERT_REQUEST_HEX(req_hex, rsp_exp_hex);
 }
 
+ZTEST(thingset_bin, test_get_record_ids)
+{
+    const char req_hex[] = "01 82 19 0600 01"; /* [0x600, 0x01] */
+    const char rsp_exp_hex[] =
+        "85 F6 AE "
+        "19 06 01 02 "                      /* 0x0601:2, */
+        "19 06 02 f5  "                     /* 0x0602:true, */
+        "19 06 03 08 19 06 04 27 "          /* 0x0603:8,0x0604:-8, */
+        "19 06 05 10 19 06 06 2f "          /* 0x0605:16,0x0606:-16, */
+        "19 06 07 18 20 19 06 08 38 1f "    /* 0x0607:32,0x0608:-32, */
+        "19 06 09 18 40 19 06 0a 38 3f "    /* 0x0609:64,0x060A:-64, */
+        "19 06 0b fa c0 4c cc cd "          /* 0x0601B:-3.2 */
+        "19 06 0c c4 82 21 38 1f "          /* 0x060C: 4([-2, -32])*/
+        "19 06 0d 66 73 74 72 69 6e 67 "    /* 0x060D:"string" */
+        "19 06 0f "                         /* 0x060E: */
+        "83 fa 3f 9d 70 a4 fa 40 91 eb 85 fa 40 fc 7a e1";  /* [1.23, 4.56, 7.89] */
+
+    THINGSET_ASSERT_REQUEST_HEX(req_hex, rsp_exp_hex);
+}
+
 ZTEST(thingset_bin, test_get_record_names)
 {
     const char req_hex[] = "01 69 5265636F7264732F31"; /* Records/1 */


### PR DESCRIPTION
So far it was not possible to get records using the binary mode with IDs, as we need the record index in addition to the data object ID. If paths are used instead of IDs, the index is part of the path.

This PR introduces support for specifying the record data object ID and the index as a two-element array. As an alternative we considered using a decimal fraction type instead of the an integer, where the digits behind the comma would specify the index. However, this requires more space (because of the tag) and may not be supported very well by all CBOR parsers.

Support for reports containing records still needs to be added in a follow-up PR.