### PR TITLE
Binary mode: Add support for reports containing records

### DIFF
--- a/src/thingset.c
+++ b/src/thingset.c
@@ -366,6 +366,10 @@ int thingset_report_path(struct thingset_context *ts, char *buf, size_t buf_size
             ts->endpoint.use_ids = true;
             thingset_bin_setup(ts, 1);
             break;
+        case THINGSET_BIN_NAMES_VALUES:
+            ts->endpoint.use_ids = false;
+            thingset_bin_setup(ts, 1);
+            break;
         default:
             err = -THINGSET_ERR_NOT_IMPLEMENTED;
             goto out;

--- a/tests/common/test_utils.h
+++ b/tests/common/test_utils.h
@@ -107,6 +107,26 @@
         } \
     }
 
+#define THINGSET_ASSERT_REPORT_HEX_NAMES(path, rpt_exp_hex, err_exp) \
+    { \
+        uint8_t rpt_act[THINGSET_TEST_BUF_SIZE]; \
+        uint8_t rpt_act_hex[THINGSET_TEST_BUF_SIZE]; \
+        uint8_t rpt_exp[THINGSET_TEST_BUF_SIZE]; \
+        int rpt_act_len = \
+            thingset_report_path(&ts, rpt_act, sizeof(rpt_act), path, THINGSET_BIN_NAMES_VALUES); \
+        int rpt_exp_len = hex2bin_spaced(rpt_exp_hex, rpt_exp, sizeof(rpt_exp)); \
+        bin2hex_spaced(rpt_act, rpt_act_len, rpt_act_hex, sizeof(rpt_act_hex)); \
+        if (err_exp > 0) { \
+            zassert_true(rpt_act_len > 0, "err_act: 0x%02X", -rpt_act_len); \
+            zassert_mem_equal(rpt_exp, rpt_act, MAX(rpt_act_len, rpt_exp_len), "act: %s\nexp: %s", \
+                              rpt_act_hex, rpt_exp_hex); \
+            zassert_equal(rpt_act_len, err_exp, "act: %d, exp: %d", rpt_act_len, err_exp); \
+        } \
+        else { \
+            zassert_equal(rpt_act_len, err_exp, "act: %d, exp: %d", rpt_act_len, err_exp); \
+        } \
+    }
+
 #define THINGSET_ASSERT_EXPORT_TXT(subsets, rsp_exp, err_exp) \
     { \
         uint8_t rsp_act[THINGSET_TEST_BUF_SIZE]; \

--- a/tests/protocol/src/bin.c
+++ b/tests/protocol/src/bin.c
@@ -798,6 +798,44 @@ ZTEST(thingset_bin, test_report_group_ids)
     THINGSET_ASSERT_REPORT_HEX_IDS("Nested/Obj1", rpt_exp_hex, 21);
 }
 
+ZTEST(thingset_bin, test_report_record_names)
+{
+    const char rpt_exp_hex[] =
+        "1F 69 5265636F7264732F31 AE "                  /* Records/1 */
+        "63 74 5f 73 02 "                               /* "t_s":2, */
+        "65 77 42 6f 6f 6c f5 "                         /* "wBool":true, */
+        "63 77 55 38 08 63 77 49 38 27 "                /* "wU8":8,"wI8":-8, */
+        "64 77 55 31 36 10 64 77 49 31 36 2f "          /* "wU16":16,"wI16":-16, */
+        "64 77 55 33 32 18 20 64 77 49 33 32 38 1f "    /* "wU32":32,"wI32":-32, */
+        "64 77 55 36 34 18 40 64 77 49 36 34 38 3f "    /* "wU64":64,"wI64":-64, */
+        "64 77 46 33 32 fa c0 4c cc cd "                /* "wF32":-3.2 */
+        "68 77 44 65 63 46 72 61 63 c4 82 21 38 1f "    /* "wDecFrac": 4([-2, -32])*/
+        "67 77 53 74 72 69 6e 67 66 73 74 72 69 6e 67 " /* "wString":"string" */
+        "69 77 46 33 32 41 72 72 61 79 "                /* "wF32Array": */
+        "83 fa 3f 9d 70 a4 fa 40 91 eb 85 fa 40 fc 7a e1"; /* [1.23, 4.56, 7.89] */
+
+    THINGSET_ASSERT_REPORT_HEX_NAMES("Records/1", rpt_exp_hex, 139);
+}
+
+ZTEST(thingset_bin, test_report_record_ids)
+{
+    const char rpt_exp_hex[] =
+        "1F 82 19 0600 01 AE "              /* [0x600, 0x01] */
+        "19 06 01 02 "                      /* 0x0601:2, */
+        "19 06 02 f5 "                      /* 0x0602:true, */
+        "19 06 03 08 19 06 04 27 "          /* 0x0603:8,0x0604:-8, */
+        "19 06 05 10 19 06 06 2f "          /* 0x0605:16,0x0606:-16, */
+        "19 06 07 18 20 19 06 08 38 1f "    /* 0x0607:32,0x0608:-32, */
+        "19 06 09 18 40 19 06 0a 38 3f "    /* 0x0609:64,0x060A:-64, */
+        "19 06 0b fa c0 4c cc cd "          /* 0x0601B:-3.2 */
+        "19 06 0c c4 82 21 38 1f "          /* 0x060C: 4([-2, -32])*/
+        "19 06 0d 66 73 74 72 69 6e 67 "    /* 0x060D:"string" */
+        "19 06 0f "                         /* 0x060E: */
+        "83 fa 3f 9d 70 a4 fa 40 91 eb 85 fa 40 fc 7a e1";  /* [1.23, 4.56, 7.89] */
+
+    THINGSET_ASSERT_REPORT_HEX_IDS("Records/1", rpt_exp_hex, 96);
+}
+
 ZTEST(thingset_bin, test_export_subset_ids)
 {
     const char rsp_exp_hex[] =


### PR DESCRIPTION
IDs are encoded as a two-element array with the actual ID as the first element and the record index as the second element.

Related PR for spec: https://github.com/ThingSet/thingset.github.io/pull/27