### PR TITLE
Tests: Fix compiler flags to treat warnings as errors

### DIFF
--- a/tests/cpp/testcase.yaml
+++ b/tests/cpp/testcase.yaml
@@ -4,4 +4,4 @@ tests:
   thingset.cpp:
     integration_platforms:
       - native_posix
-    extra_args: EXTRA_CFLAGS=-Wno-error
+    extra_args: EXTRA_CFLAGS=-Werror

--- a/tests/protocol/testcase.yaml
+++ b/tests/protocol/testcase.yaml
@@ -5,11 +5,11 @@ tests:
     integration_platforms:
       - native_posix
       - native_posix_64
-    extra_args: EXTRA_CFLAGS=-Wno-error
+    extra_args: EXTRA_CFLAGS=-Werror
   thingset.protocol.objectlookup:
     integration_platforms:
       - native_posix
       - native_posix_64
-    extra_args: EXTRA_CFLAGS=-Wno-error
+    extra_args: EXTRA_CFLAGS=-Werror
     extra_configs:
       - CONFIG_THINGSET_OBJECT_LOOKUP_MAP=y

--- a/tests/report/testcase.yaml
+++ b/tests/report/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     integration_platforms:
       - native_posix
       - native_posix_64
-    extra_args: EXTRA_CFLAGS=-Wno-error
+    extra_args: EXTRA_CFLAGS=-Werror


### PR DESCRIPTION
Issue spotted by @garethpotter as part of #15.