### PR TITLE
Binary mode: Add support for deserializing half floats (16-bit)

### DIFF
--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -524,7 +524,7 @@ static int bin_deserialize_simple_value(struct thingset_context *ts,
             success = zcbor_int_decode(ts->decoder, data.i8, 1);
             break;
         case THINGSET_TYPE_F32:
-            success = zcbor_float32_decode(ts->decoder, data.f32);
+            success = zcbor_float16_32_decode(ts->decoder, data.f32);
             if (!success) {
                 /* try integer type */
                 int32_t tmp;
@@ -567,7 +567,7 @@ static int bin_deserialize_simple_value(struct thingset_context *ts,
                     *mantissa = i32;
                     success = true;
                 }
-                else if (zcbor_float32_decode(ts->decoder, &f32) == true) {
+                else if (zcbor_float16_32_decode(ts->decoder, &f32) == true) {
                     for (int i = 0; i < exponent; i++) {
                         f32 /= 10.0F;
                     }

--- a/tests/protocol/src/bin.c
+++ b/tests/protocol/src/bin.c
@@ -487,6 +487,17 @@ ZTEST(thingset_bin, test_update_wrong_endpoint_id)
     THINGSET_ASSERT_REQUEST_HEX(req_hex, rsp_exp_hex);
 }
 
+ZTEST(thingset_bin, test_update_16bit_float)
+{
+    const char req_hex[] = "07 19 0200 A1 19 020A F9 3C00";
+    const char rsp_exp_hex[] = "84 F6 F6";
+
+    THINGSET_ASSERT_REQUEST_HEX(req_hex, rsp_exp_hex);
+    zassert_equal(f32, 1.0F);
+
+    f32 = -3.2F;
+}
+
 #if CONFIG_THINGSET_BYTES_TYPE_SUPPORT
 
 ZTEST(thingset_bin, test_update_bytes_buffer)


### PR DESCRIPTION
Some encoders seem to use the quite uncommon half float type. This was previously rejected.

This PR provides a simple fix to support both types.