### PR TITLE
Fixed linker error when CONFIG_THINGSET_TEXT_MODE=n

### DIFF
--- a/src/thingset.c
+++ b/src/thingset.c
@@ -178,9 +178,11 @@ int thingset_export_subsets(struct thingset_context *ts, uint8_t *buf, size_t bu
     ts->rsp_pos = 0;
 
     switch (format) {
+#ifdef CONFIG_THINGSET_TEXT_MODE
         case THINGSET_TXT_NAMES_VALUES:
             thingset_txt_setup(ts);
             break;
+#endif
         case THINGSET_BIN_IDS_VALUES:
             ts->endpoint.use_ids = true;
             thingset_bin_setup(ts, 0);
@@ -217,9 +219,11 @@ int thingset_export_item(struct thingset_context *ts, uint8_t *buf, size_t buf_s
     ts->rsp_pos = 0;
 
     switch (format) {
+#ifdef CONFIG_THINGSET_TEXT_MODE
         case THINGSET_TXT_VALUES_ONLY:
             thingset_txt_setup(ts);
             break;
+#endif
         case THINGSET_BIN_VALUES_ONLY:
             ts->endpoint.use_ids = true;
             thingset_bin_setup(ts, 0);
@@ -371,11 +375,13 @@ int thingset_import_record(struct thingset_context *ts, const uint8_t *data, siz
     ts->endpoint = *endpoint;
 
     switch (format) {
+#ifdef CONFIG_THINGSET_TEXT_MODE
         case THINGSET_TXT_NAMES_VALUES:
             thingset_txt_setup(ts);
             ts->msg_payload = data;
             ts->api->deserialize_payload_reset(ts);
             break;
+#endif
         case THINGSET_BIN_IDS_VALUES:
             ts->endpoint.use_ids = true;
             thingset_bin_setup(ts, 0);


### PR DESCRIPTION
I compiled thingset-zephyr-sdk without text mode. A clean build complains at linker time  for thingset_txt_setup(). Fixed that with compile options.