### PR TITLE
Facilitate Multi-Threaded Access

### DIFF
--- a/src/thingset.c
+++ b/src/thingset.c
@@ -133,13 +133,10 @@ int thingset_export_subsets_progressively(struct thingset_global_context *ts, ui
                                           size_t *len)
 {
     if (*index == 0) {
-        struct thingset_context r = {
-            .context = ts,
-            .rsp = buf,
-            .rsp_size = buf_size,
-            .rsp_pos = 0,
-        };
-        *req_ctx = r;
+        req_ctx->context = ts;
+        req_ctx->rsp = buf;
+        req_ctx->rsp_size = buf_size;
+        req_ctx->rsp_pos = 0;
 
         switch (format) {
             case THINGSET_BIN_IDS_VALUES:
@@ -265,16 +262,13 @@ int thingset_import_data_progressively(struct thingset_global_context *ts, const
     int err = 0;
 
     if (*last_id == 0) {
-        struct thingset_context r = {
-            .context = ts,
-            .msg = data,
-            .msg_len = len,
-            .msg_pos = 0,
-            .rsp = NULL,
-            .rsp_size = 0,
-            .rsp_pos = 0,
-        };
-        *req_ctx = r;
+        req_ctx->context = ts;
+        req_ctx->msg = data;
+        req_ctx->msg_len = len;
+        req_ctx->msg_pos = 0;
+        req_ctx->rsp = NULL;
+        req_ctx->rsp_size = 0;
+        req_ctx->rsp_pos = 0;
 
         switch (format) {
             case THINGSET_BIN_IDS_VALUES:

--- a/src/thingset.c
+++ b/src/thingset.c
@@ -816,7 +816,7 @@ int thingset_acquire_read_lock(struct thingset_global_context *ts, k_timeout_t t
 int thingset_release_read_lock(struct thingset_global_context *ts)
 {
     atomic_t previous_count = atomic_dec(&ts->reader_count);
-    if (previous_count == 0) {
+    if (previous_count == 1) { /* will now be 0 */
         k_sem_give(&ts->sem);
     }
 

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -246,7 +246,8 @@ static int bin_serialize_value(struct thingset_context *ts,
         success = zcbor_list_start_encode(ts->encoder, UINT8_MAX);
         for (unsigned int i = 0; i < ts->context->num_objects; i++) {
             if (ts->context->data_objects[i].parent_id == object->id) {
-                zcbor_tstr_encode_ptr(ts->encoder, ts->context->data_objects[i].name, strlen(ts->data_objects[i].name));
+                zcbor_tstr_encode_ptr(ts->encoder, ts->context->data_objects[i].name,
+                                      strlen(ts->context->data_objects[i].name));
             }
         }
         success = success && zcbor_list_end_encode(ts->encoder, UINT8_MAX);

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -942,25 +942,39 @@ int thingset_bin_process(struct thingset_context *ts)
     /* requests ordered with expected highest probability first */
     switch (ts->msg[0]) {
         case THINGSET_BIN_GET:
+            thingset_acquire_read_lock(ts->context, K_FOREVER);
             ret = thingset_common_get(ts);
+            thingset_release_read_lock(ts->context);
             break;
         case THINGSET_BIN_FETCH:
+            thingset_acquire_read_lock(ts->context, K_FOREVER);
             ret = thingset_common_fetch(ts);
+            thingset_release_read_lock(ts->context);
             break;
         case THINGSET_BIN_UPDATE:
+            thingset_acquire_write_lock(ts->context, K_FOREVER);
             ret = thingset_common_update(ts);
+            thingset_release_write_lock(ts->context);
             break;
         case THINGSET_BIN_EXEC:
+            thingset_acquire_write_lock(ts->context, K_FOREVER);
             ret = thingset_common_exec(ts);
+            thingset_release_write_lock(ts->context);
             break;
         case THINGSET_BIN_CREATE:
+            thingset_acquire_write_lock(ts->context, K_FOREVER);
             ret = thingset_common_create(ts);
+            thingset_release_write_lock(ts->context);
             break;
         case THINGSET_BIN_DELETE:
+            thingset_acquire_write_lock(ts->context, K_FOREVER);
             ret = thingset_common_delete(ts);
+            thingset_release_write_lock(ts->context);
             break;
         case THINGSET_BIN_DESIRE:
+            thingset_acquire_read_lock(ts->context, K_FOREVER);
             ret = thingset_bin_desire(ts);
+            thingset_release_read_lock(ts->context);
             break;
         default:
             return -THINGSET_ERR_BAD_REQUEST;

--- a/src/thingset_internal.h
+++ b/src/thingset_internal.h
@@ -284,7 +284,7 @@ int thingset_txt_serialize_response(struct thingset_context *ts, uint8_t code, c
  *
  * @return Pointer to the data object or NULL in case of error
  */
-struct thingset_data_object *thingset_get_child_by_name(struct thingset_context *ts,
+struct thingset_data_object *thingset_get_child_by_name(struct thingset_global_context *ts,
                                                         uint16_t parent_id, const char *name,
                                                         size_t len);
 
@@ -296,7 +296,8 @@ struct thingset_data_object *thingset_get_child_by_name(struct thingset_context 
  *
  * @return Pointer to the data object or NULL in case of error
  */
-struct thingset_data_object *thingset_get_object_by_id(struct thingset_context *ts, uint16_t id);
+struct thingset_data_object *thingset_get_object_by_id(struct thingset_global_context *ts,
+                                                       uint16_t id);
 
 /**
  * Get an object by its path.
@@ -306,7 +307,7 @@ struct thingset_data_object *thingset_get_object_by_id(struct thingset_context *
  * @param path_len Length of path
  * @param index Pointer to an index which may be decoded as part of the path
  */
-struct thingset_data_object *thingset_get_object_by_path(struct thingset_context *ts,
+struct thingset_data_object *thingset_get_object_by_path(struct thingset_global_context *ts,
                                                          const char *path, size_t path_len,
                                                          int *index);
 
@@ -320,7 +321,7 @@ struct thingset_data_object *thingset_get_object_by_path(struct thingset_context
  *
  * @return Length of the path or negative ThingSet response code in case of error
  */
-int thingset_get_path(struct thingset_context *ts, char *buf, size_t size,
+int thingset_get_path(struct thingset_global_context *ts, char *buf, size_t size,
                       const struct thingset_data_object *obj);
 
 /**
@@ -331,8 +332,8 @@ int thingset_get_path(struct thingset_context *ts, char *buf, size_t size,
  * @param buf Pointer to the buffer to store the path.
  * @param size Size of the buffer.
  */
-int thingset_get_type_name(struct thingset_context *ts, const struct thingset_data_object *obj,
-                           char *buf, size_t size);
+int thingset_get_type_name(struct thingset_global_context *ts,
+                           const struct thingset_data_object *obj, char *buf, size_t size);
 
 /**
  * Process text mode desire.

--- a/tests/cpp/src/init.cpp
+++ b/tests/cpp/src/init.cpp
@@ -15,8 +15,8 @@
 
 ZTEST(thingset_init_cpp, test_init_data_objects)
 {
-    struct thingset_context ts_local;
-    struct thingset_context ts_global;
+    struct thingset_global_context ts_local;
+    struct thingset_global_context ts_global;
 
     /* initialized with array declared in data.c */
     thingset_init(&ts_local, data_objects, data_objects_size);

--- a/tests/protocol/src/bin.c
+++ b/tests/protocol/src/bin.c
@@ -13,7 +13,7 @@
 #include "data.h"
 #include "test_utils.h"
 
-static struct thingset_context ts;
+static struct thingset_global_context ts;
 
 ZTEST(thingset_bin, test_get_root_ids)
 {
@@ -910,8 +910,9 @@ ZTEST(thingset_bin, test_export_subsets_progressively)
     int data_exp_len = hex2bin_spaced(data_exp_hex, data_exp, sizeof(data_exp));
 
     index = 0;
+    struct thingset_context req_ctx;
     ret = thingset_export_subsets_progressively(&ts, buf_large, sizeof(buf_large), SUBSET_LIVE,
-                                                THINGSET_BIN_IDS_VALUES, &index, &len);
+                                                THINGSET_BIN_IDS_VALUES, &req_ctx, &index, &len);
     zassert_true(ret >= 0);
     zassert_equal(len, data_exp_len);
     zassert_mem_equal(data_exp, buf_large, data_exp_len);
@@ -919,8 +920,9 @@ ZTEST(thingset_bin, test_export_subsets_progressively)
     index = 0;
     size_t pos = 0;
     do {
-        ret = thingset_export_subsets_progressively(&ts, buf_small, sizeof(buf_small), SUBSET_LIVE,
-                                                    THINGSET_BIN_IDS_VALUES, &index, &len);
+        ret =
+            thingset_export_subsets_progressively(&ts, buf_small, sizeof(buf_small), SUBSET_LIVE,
+                                                  THINGSET_BIN_IDS_VALUES, &req_ctx, &index, &len);
         zassert_true(ret >= 0);
         zassert_mem_equal(data_exp + pos, buf_small, len);
         pos += len;

--- a/tests/protocol/src/common.c
+++ b/tests/protocol/src/common.c
@@ -12,7 +12,7 @@
 
 #include "test_utils.h"
 
-static struct thingset_context ts;
+static struct thingset_global_context ts;
 
 ZTEST(thingset_common, test_endpoint_from_path)
 {

--- a/tests/protocol/src/init.c
+++ b/tests/protocol/src/init.c
@@ -13,8 +13,8 @@ extern size_t data_objects_size;
 
 ZTEST(thingset_init, test_init_data_objects)
 {
-    struct thingset_context ts_local;
-    struct thingset_context ts_global;
+    struct thingset_global_context ts_local;
+    struct thingset_global_context ts_global;
 
     /* initialized with array declared in data.c */
     thingset_init(&ts_local, data_objects, data_objects_size);

--- a/tests/protocol/src/txt.c
+++ b/tests/protocol/src/txt.c
@@ -13,7 +13,7 @@
 #include "data.h"
 #include "test_utils.h"
 
-static struct thingset_context ts;
+static struct thingset_global_context ts;
 
 bool update_callback_called;
 

--- a/tests/report/src/report.c
+++ b/tests/report/src/report.c
@@ -12,7 +12,7 @@
 #include "test_utils.h"
 
 #ifdef CONFIG_THINGSET_REPORT_RECORD_SERIALIZATION
-static struct thingset_context ts;
+static struct thingset_global_context ts;
 
 ZTEST(thingset_report, test_report_bin)
 {

--- a/tests/serde/src/main.c
+++ b/tests/serde/src/main.c
@@ -11,7 +11,7 @@
 
 #include "test_utils.h"
 
-static struct thingset_context ts;
+static struct thingset_global_context ts;
 
 static void patch_json_get_cbor(const char *name, const char *json_value,
                                 const char *cbor_value_hex)


### PR DESCRIPTION
Add a request per-context and a reader-writer lock to facilitate uncontended concurrent reads.