### PR TITLE
Changing zcbor remote back to zephyr's repo.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -4,8 +4,6 @@ manifest:
   remotes:
     - name: zephyrproject-rtos
       url-base: https://github.com/zephyrproject-rtos
-    - name: NordicSemiconductor
-      url-base: https://github.com/NordicSemiconductor
 
   projects:
     - name: zephyr
@@ -14,8 +12,7 @@ manifest:
       import:
         name-allowlist:
           - edtt
-    # Use Nordic repo to pull in https://github.com/NordicSemiconductor/zcbor/pull/407
     - name: zcbor
-      remote: NordicSemiconductor
+      remote: zephyrproject-rtos
       revision: 16648fb060d857f164635ca4e8eaa716d906d244
       path: modules/lib/zcbor


### PR DESCRIPTION
Now that zephyr remote does have necessary zcbor update, it is no longer necessary to have Nordic's remote in west.yml.