### PR TITLE
Binary mode: Add support for importing reports

### DIFF
--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1823,6 +1823,25 @@ int thingset_import_data(struct thingset_context *ts, const uint8_t *data, size_
                          uint8_t auth_flags, enum thingset_data_format format);
 
 /**
+ * Import report into data objects.
+ *
+ * This function allows importing data objects from a received report.
+ *
+ * Unknown data items are silently ignored.
+ *
+ * @param ts Pointer to ThingSet context.
+ * @param data Buffer containing ID/value map that should be written to the data objects
+ * @param len Length of the data in the buffer
+ * @param auth_flags Authentication flags to be used in this function (to override auth_flags)
+ * @param format Protocol data format to be used (text, binary with IDs or binary with names)
+ * @param subset The subset associated with the published report
+ *
+ * @returns 0 for success or negative ThingSet response code in case of error
+ */
+int thingset_import_report(struct thingset_context *ts, const uint8_t *data, size_t len,
+                           uint8_t auth_flags, enum thingset_data_format format, uint16_t subset);
+
+/**
  * EXPERIMENTAL
  *
  * Import data from a buffer into data objects.

--- a/src/thingset_bin.c
+++ b/src/thingset_bin.c
@@ -931,6 +931,22 @@ int thingset_bin_import_data(struct thingset_context *ts, uint8_t auth_flags,
     return ts->api->deserialize_finish(ts);
 }
 
+int thingset_bin_import_report(struct thingset_context *ts, uint8_t auth_flags, uint16_t subset)
+{
+    uint32_t id = 0;
+
+    if (ts->msg_payload[0] != THINGSET_BIN_REPORT) {
+        return -THINGSET_ERR_UNSUPPORTED_FORMAT;
+    }
+
+    zcbor_uint32_decode(ts->decoder, &id);
+    if (id != subset) {
+        return -THINGSET_ERR_NOT_FOUND;
+    }
+
+    return thingset_bin_import_data(ts, auth_flags, subset);
+}
+
 int thingset_bin_process(struct thingset_context *ts)
 {
     int ret;

--- a/src/thingset_internal.h
+++ b/src/thingset_internal.h
@@ -377,6 +377,8 @@ void thingset_bin_setup(struct thingset_context *ts, size_t buf_offset);
 int thingset_bin_import_data(struct thingset_context *ts, uint8_t auth_flags,
                              enum thingset_data_format format);
 
+int thingset_bin_import_report(struct thingset_context *ts, uint8_t auth_flags, uint16_t subset);
+
 int thingset_bin_import_data_progressively(struct thingset_context *ts, uint8_t auth_flags,
                                            size_t size, uint32_t *last_id, size_t *consumed);
 

--- a/tests/common/data.c
+++ b/tests/common/data.c
@@ -423,3 +423,23 @@ struct thingset_data_object data_objects[] = {
 };
 
 size_t data_objects_size = ARRAY_SIZE(data_objects);
+
+/*
+ * Test case for importing reports with initial zero values.
+ */
+uint32_t report_timestamp = 0;
+bool report_b = false;
+int32_t report_nested_beginning = 0;
+float report_nested_obj2_item2 = 0.0;
+
+struct thingset_data_object report_data_objects[] = {
+    THINGSET_ITEM_UINT32(THINGSET_ID_ROOT, 0x10, "t_s", &report_timestamp, THINGSET_ANY_RW,
+                         SUBSET_LIVE),
+    THINGSET_ITEM_BOOL(0x200, 0x201, "wBool", &report_b, THINGSET_ANY_RW, SUBSET_LIVE),
+    THINGSET_ITEM_INT32(0x700, 0x701, "rBeginning", &report_nested_beginning, THINGSET_ANY_RW,
+                        SUBSET_LIVE),
+    THINGSET_ITEM_FLOAT(0x706, 0x708, "rItem2_V", &report_nested_obj2_item2, 1, THINGSET_ANY_RW,
+                        SUBSET_LIVE),
+};
+
+size_t report_data_objects_size = ARRAY_SIZE(report_data_objects);


### PR DESCRIPTION
Enable multiple devices to exchange structured data by adding the ability to interpret binary reports received from other systems.

For an example of its usage, see: [Example: Importing Reports](https://github.com/ThingSet/thingset-zephyr-sdk/compare/main...e-battery-systems:thingset-zephyr-sdk:test-importing-reports#diff-f566fcfafa9b4541b0580c6d304c91ff1e31c9212d6267345c4c60acf7528c47R387-R389).

This implementation may address https://github.com/LibreSolar/bms-c1/issues/63.