### PR TITLE
Include object in change callback

### DIFF
--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1364,11 +1364,15 @@ enum thingset_callback_reason
     THINGSET_CALLBACK_POST_WRITE, /**< Function was called after deserializing data of the group */
 };
 
+struct thingset_data_object;
+
 /** Function to be called before/after read/write operations to groups. */
-typedef void (*thingset_group_callback_t)(enum thingset_callback_reason cb_reason);
+typedef int (*thingset_group_callback_t)(enum thingset_callback_reason cb_reason,
+                                         const struct thingset_data_object *obj);
 
 /** Function to be called before/after read/write operations to records. */
-typedef void (*thingset_records_callback_t)(enum thingset_callback_reason cb_reason, int index);
+typedef int (*thingset_records_callback_t)(enum thingset_callback_reason cb_reason, int index,
+                                           const struct thingset_data_object *obj);
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/src/thingset_common.c
+++ b/src/thingset_common.c
@@ -27,7 +27,7 @@ int thingset_common_serialize_group(struct thingset_context *ts,
     }
 
     if (object->data.group_callback != NULL) {
-        object->data.group_callback(THINGSET_CALLBACK_PRE_READ);
+        object->data.group_callback(THINGSET_CALLBACK_PRE_READ, object);
     }
 
     for (unsigned int i = 0; i < ts->num_objects; i++) {
@@ -42,7 +42,7 @@ int thingset_common_serialize_group(struct thingset_context *ts,
     }
 
     if (object->data.group_callback != NULL) {
-        object->data.group_callback(THINGSET_CALLBACK_POST_READ);
+        object->data.group_callback(THINGSET_CALLBACK_POST_READ, object);
     }
 
     return ts->api->serialize_map_end(ts);
@@ -128,7 +128,7 @@ int thingset_common_serialize_record(struct thingset_context *ts,
     }
 
     if (records->callback != NULL) {
-        records->callback(THINGSET_CALLBACK_PRE_READ, record_index);
+        records->callback(THINGSET_CALLBACK_PRE_READ, record_index, object);
     }
 
     const struct thingset_data_object *item = thingset_get_object_by_id(ts, object->id) + 1;
@@ -151,7 +151,7 @@ int thingset_common_serialize_record(struct thingset_context *ts,
     }
 
     if (records->callback != NULL) {
-        records->callback(THINGSET_CALLBACK_POST_READ, record_index);
+        records->callback(THINGSET_CALLBACK_POST_READ, record_index, object);
     }
 
     return ts->api->serialize_map_end(ts);
@@ -184,13 +184,13 @@ int thingset_common_get(struct thingset_context *ts)
             parent = thingset_get_object_by_id(ts, ts->endpoint.object->parent_id);
 
             if (parent != NULL && parent->data.group_callback != NULL) {
-                parent->data.group_callback(THINGSET_CALLBACK_PRE_READ);
+                parent->data.group_callback(THINGSET_CALLBACK_PRE_READ, ts->endpoint.object);
             }
 
             err = ts->api->serialize_value(ts, ts->endpoint.object);
 
             if (parent != NULL && parent->data.group_callback != NULL) {
-                parent->data.group_callback(THINGSET_CALLBACK_POST_READ);
+                parent->data.group_callback(THINGSET_CALLBACK_POST_READ, ts->endpoint.object);
             }
             break;
     }
@@ -232,14 +232,16 @@ int thingset_common_fetch(struct thingset_context *ts)
         }
 
         /* fetch values */
-        if (ts->endpoint.object->data.group_callback != NULL) {
-            ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_PRE_READ);
-        }
 
         const struct thingset_data_object *object;
         while ((err = ts->api->deserialize_child(ts, &object))
                != -THINGSET_ERR_DESERIALIZATION_FINISHED)
         {
+
+            if (ts->endpoint.object->data.group_callback != NULL) {
+                ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_PRE_READ, object);
+            }
+
             if (err != 0) {
                 return ts->api->serialize_response(ts, -err, NULL);
             }
@@ -281,7 +283,7 @@ int thingset_common_fetch(struct thingset_context *ts)
         }
 
         if (ts->endpoint.object->data.group_callback != NULL) {
-            ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_POST_READ);
+            ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_POST_READ, object);
         }
     }
     else {
@@ -346,7 +348,10 @@ int thingset_common_update(struct thingset_context *ts)
     ts->api->deserialize_map_start(ts);
 
     if (ts->endpoint.object->data.group_callback != NULL) {
-        ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_PRE_WRITE);
+        int err = ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_PRE_WRITE, object);
+        if (err < 0) {
+            return ts->api->serialize_response(ts, -err, NULL);
+        }
     }
 
     /* actually write data */
@@ -364,7 +369,10 @@ int thingset_common_update(struct thingset_context *ts)
     }
 
     if (ts->endpoint.object->data.group_callback != NULL) {
-        ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_POST_WRITE);
+        int err = ts->endpoint.object->data.group_callback(THINGSET_CALLBACK_POST_WRITE, object);
+        if (err < 0) {
+            return ts->api->serialize_response(ts, -err, NULL);
+        }
     }
 
     /*

--- a/tests/common/data.c
+++ b/tests/common/data.c
@@ -103,7 +103,8 @@ int group_callback_pre_read_count;
 int group_callback_post_read_count;
 int group_callback_pre_write_count;
 int group_callback_post_write_count;
-static void group_callback(enum thingset_callback_reason reason)
+static int group_callback(enum thingset_callback_reason reason,
+                          const struct thingset_data_object *obj)
 {
     switch (reason) {
         case THINGSET_CALLBACK_PRE_READ:
@@ -119,6 +120,7 @@ static void group_callback(enum thingset_callback_reason reason)
             group_callback_post_write_count++;
             break;
     }
+    return 0;
 }
 
 /* Records */
@@ -164,7 +166,8 @@ static struct test_dyn_struct dyn_records = {
 int dyn_records_callback_pre_read_count;
 int dyn_records_callback_post_read_count;
 int dyn_records_callback_index;
-static void dyn_records_callback(enum thingset_callback_reason reason, int index)
+static int dyn_records_callback(enum thingset_callback_reason reason, int index,
+                                const struct thingset_data_object *object)
 {
     switch (reason) {
         case THINGSET_CALLBACK_PRE_READ:
@@ -180,9 +183,10 @@ static void dyn_records_callback(enum thingset_callback_reason reason, int index
             dyn_records_callback_post_read_count++;
             break;
         default:
-            return;
+            return 0;
     }
     dyn_records_callback_index = index;
+    return 0;
 }
 
 THINGSET_DEFINE_DYN_RECORDS(dyn_records_obj, &dyn_records, 10, dyn_records_callback);


### PR DESCRIPTION
It is useful to be able to know which object is the subject of a change.