### PR TITLE
Add API to abort a progressive export of subsets

### DIFF
--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1777,7 +1777,7 @@ int thingset_export_subsets_progressively(struct thingset_context *ts, uint8_t *
 
 /**
  * Aborts the export of data to the buffer passed to @ref
- * thingset_export_subsets_progressively. Call this method if.
+ * thingset_export_subsets_progressively. Call this method if
  * the export has failed outside ThingSet code.
  *
  * @param ts Pointer to ThingSet context.

--- a/include/thingset.h
+++ b/include/thingset.h
@@ -1776,6 +1776,17 @@ int thingset_export_subsets_progressively(struct thingset_context *ts, uint8_t *
                                           size_t *len);
 
 /**
+ * Aborts the export of data to the buffer passed to @ref
+ * thingset_export_subsets_progressively. Call this method if.
+ * the export has failed outside ThingSet code.
+ *
+ * @param ts Pointer to ThingSet context.
+ *
+ * @returns 0 for success
+ */
+int thingset_export_subsets_progressively_abort(struct thingset_context *ts);
+
+/**
  * Export id, value and/or name of a single data item.
  *
  * This function is typically used together with thingset_iterate_subsets to export items of a

--- a/src/thingset.c
+++ b/src/thingset.c
@@ -163,6 +163,12 @@ int thingset_export_subsets_progressively(struct thingset_context *ts, uint8_t *
     return ret;
 }
 
+int thingset_export_subsets_progressively_abort(struct thingset_context *ts)
+{
+    k_sem_give(&ts->lock);
+    return 0;
+}
+
 int thingset_export_subsets(struct thingset_context *ts, uint8_t *buf, size_t buf_size,
                             uint16_t subsets, enum thingset_data_format format)
 {


### PR DESCRIPTION
If an export fails for some reason external to ThingSet (e.g. externally-handled EEPROM write fails), this method provides a way to release the acquired internal lock.